### PR TITLE
builder to add vimeo videos with ids of any length

### DIFF
--- a/MapTour/src/app/storymaps/maptour/builder/AddPopup.js
+++ b/MapTour/src/app/storymaps/maptour/builder/AddPopup.js
@@ -865,7 +865,7 @@ define(["esri/dijit/Geocoder",
 			function getVimeoThumbnail(url)
 			{
 				var resultDeferred = new Deferred();
-				var test = /vimeo\.com\/([0-9]{8})/.exec(url);
+				var test = /vimeo\.com\/([0-9]+$)/.exec(url);
 				
 				if( ! test || test.length != 2 )
 					resultDeferred.reject();
@@ -893,7 +893,7 @@ define(["esri/dijit/Geocoder",
 			
 			function getVimeoEmbed(url)
 			{
-				var test = /vimeo\.com\/([0-9]{8})/.exec(url);
+				var test = /vimeo\.com\/([0-9]+$)/.exec(url);
 				return test && test.length == 2 ? '//player.vimeo.com/video/' + test[1] : '';
 			}
 			


### PR DESCRIPTION
https://github.com/Esri/map-tour-storytelling-template-js/issues/26

When adding a new map tour point in the builder and selecting a vimeo video, the builder only worked correctly in finding a thumbnail and video if the id was exactly 8 digits. This isn't always the case with vimeo videos. The latest videos now have 9 digits and there are even videos in the single digits. 

Made a single change in two places to allow for arbitrary length ids. I tested adding a video with 9 digits and one with 7 digits. Both worked fine. Before, the one with 9 digits would have tried to find the video related to the first 8 digits in the id and the video with 7 digits would have failed.
