### PR TITLE
stotymap feature layer with polygon support

### DIFF
--- a/MapTour/src/app/storymaps/maptour/core/FeatureServiceManager.js
+++ b/MapTour/src/app/storymaps/maptour/core/FeatureServiceManager.js
@@ -2,12 +2,14 @@ define(["storymaps/maptour/core/TourPointAttributes",
 		"storymaps/maptour/core/MapTourHelper",
 		"esri/graphic",
 		"esri/geometry/Point",
+		"esri/geometry/Polygon",
 		"dojo/topic"], 
 	function (
 		TourPointAttributes, 
 		MapTourHelper, 
 		Graphic, 
 		Point, 
+		Polygon,
 		topic
 	) {
 		return function FeatureServiceManager()
@@ -31,16 +33,29 @@ define(["storymaps/maptour/core/TourPointAttributes",
 				if( isFSWithURLFields  || ! featureLayer.hasAttachments ) {
 					for (i = 0; i < featureLayer.graphics.length; i++) {
 						var feature = featureLayer.graphics[i];
-						var graphic = new Graphic(
-							new Point(
-								feature.geometry.x,
-								feature.geometry.y,
-								feature.geometry.spatialReference
-							),
-							null,
-							new TourPointAttributes(feature)
-						);
-						graphics.push(graphic);
+						//added code here to support point & polygon
+						if(feature.geometry.type == "point") {
+							var graphic = new Graphic(
+								new Point(
+									feature.geometry.x,
+									feature.geometry.y,
+									feature.geometry.spatialReference
+								),
+								null,
+								new TourPointAttributes(feature)
+							);
+							graphics.push(graphic);
+						}
+						else if(feature.geometry.type == "polygon") {
+						//get the centroid when the feature is polygon
+							var graphic = new Graphic(
+								new Point( feature.geometry.getCentroid() ),
+								null,
+								new TourPointAttributes(feature)
+							);
+							graphics.push(graphic);
+						}
+//						graphics.push(graphic);
 					}
 					publishCompleteEvent();
 				}
@@ -80,21 +95,38 @@ define(["storymaps/maptour/core/TourPointAttributes",
 					
 					// Check the type of attachment
 					if( MapTourHelper.isSupportedImgExt(pict.name) && MapTourHelper.isSupportedImgExt(thumb.name) ) {
-						var graphic = new Graphic(
-							new Point(
-								feature.geometry.x,
-								feature.geometry.y,
-								feature.geometry.spatialReference
-							),
-							null,
-							new TourPointAttributes(
-								feature, 
-								pict.url, 
-								thumb.url
-							)
-						);
+						//added code here to support point & polygon
+						if(feature.geometry.type == "point") {
+							var graphic = new Graphic(
+								new Point(
+									feature.geometry.x,
+									feature.geometry.y,
+									feature.geometry.spatialReference
+								),
+								null,
+								new TourPointAttributes(
+									feature, 
+									pict.url, 
+									thumb.url
+								)
+							);
+							graphics.push(graphic);
+						}
+						else if(feature.geometry.type == "polygon") {
+						//get the centroid when the feature is polygon
+							var graphic = new Graphic(
+								new Point( feature.geometry.getCentroid() ),
+								null,
+								new TourPointAttributes(
+									feature, 
+									pict.url, 
+									thumb.url
+								)
+							);
+							graphics.push(graphic);
+						}
 						
-						graphics.push(graphic);
+//						graphics.push(graphic);
 					}
 				}
 				

--- a/MapTour/src/app/storymaps/maptour/core/MainView.js
+++ b/MapTour/src/app/storymaps/maptour/core/MainView.js
@@ -282,7 +282,9 @@ define(["storymaps/maptour/core/WebApplicationData",
 							layerId = layerId.split('_').slice(0,1).join('_');	
 						
 						// Exclude map notes and not point layers
-						if( layerId.match(/^mapNotes_/) || layer.geometryType != "esriGeometryPoint" )
+						// changed code to support Polygon
+//						if( layerId.match(/^mapNotes_/) || layer.geometryType != "esriGeometryPoint" )
+						if( layerId.match(/^mapNotes_/) || (layer.geometryType != "esriGeometryPoint" && layer.geometryType != "esriGeometryPolygon") )
 							continue;
 						
 						// Loop through webmap layers to see if title match

--- a/MapTour/src/app/storymaps/maptour/core/TourData.js
+++ b/MapTour/src/app/storymaps/maptour/core/TourData.js
@@ -8,6 +8,7 @@ define(["storymaps/maptour/core/WebApplicationData",
 		"esri/layers/FeatureLayer",
 		"esri/graphic",
 		"esri/geometry/Point",
+		"esri/geometry/Polygon",
 		"dojo/topic"],
 	function(
 		WebApplicationData, 
@@ -20,6 +21,7 @@ define(["storymaps/maptour/core/WebApplicationData",
 		FeatureLayer,
 		Graphic,
 		Point,
+		Polygon,
 		topic
 	){
 		/**
@@ -532,7 +534,14 @@ define(["storymaps/maptour/core/WebApplicationData",
 				var nbPointsBeforeImport = this.getTourPoints(false).length;
 				
 				$.each(featureCollection.featureSet.features, function(i, feature){
-					addTourPointUsingAttributes(new Point(feature.geometry), feature.attributes);
+					//added code here to support point & polygon
+					if(feature.geometry.type == "point") {
+						addTourPointUsingAttributes(new Point(feature.geometry), feature.attributes);
+					}
+					else if(feature.geometry.type == "polygon") {
+						addTourPointUsingAttributes(new Point(feature.geometry.getCentroid()), feature.attributes);
+					}
+//					addTourPointUsingAttributes(new Point(feature.geometry), feature.attributes);
 				});
 				
 				processPointsOrder( computeTourPointOrderFromConfig() );


### PR DESCRIPTION
Hello

Story Map is a great tool for story telling with GIS data.
Now we got a feature layer with polygon shape.
But unfortunately it only works with point data and I found that there are some requests for polygon.
So I tried to change the code so that it also works with polygon feature layer.
I just put the centroid of the polygon wherever necessary and also change few condition to support polygon.
Please review my fork & pull request. 
It may not be fully complete, but it works with our current polygon feature and webmap.
So I think it can be a good start.

Have a great long weekend.
Thanks in advance
Sharif Ahmed
9/2/2016
